### PR TITLE
Updates for 0.13 docs

### DIFF
--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/project-setup/react-native-expo.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/project-setup/react-native-expo.mdx
@@ -4,7 +4,7 @@ import { CodeGroup } from "@/components/forMdx";
 
 # React Native (Expo) Installation and Setup
 
-Jazz supports Expo through the dedicated `jazz-expo` package, which is specifically designed for Expo applications.
+Jazz supports Expo through the dedicated `jazz-expo` package, which is specifically designed for Expo applications. If you're building for React Native without Expo, please refer to the [React Native](/docs/react-native/project-setup) guide instead.
 
 Jazz requires an [Expo development build](https://docs.expo.dev/develop/development-builds/introduction/) using [Expo Prebuild](https://docs.expo.dev/workflow/prebuild/) for native code. It is **not compatible** with Expo Go. Jazz also supports the [New Architecture](https://docs.expo.dev/guides/new-architecture/).
 
@@ -25,11 +25,11 @@ Tested with:
 (Skip this step if you already have one)
 
 <CodeGroup>
-  ```bash
+```bash
 npx create-expo-app -e with-router-tailwind my-jazz-app
 cd my-jazz-app
 npx expo prebuild
-  ```
+```
 </CodeGroup>
 
 ### Install dependencies
@@ -61,7 +61,7 @@ npx expo install --fix
 
 ### Install CocoaPods
 
-If you're compiling for iOS, you'll need to install CocoaPods for your project. Expo recommend using the [`pod-install` command](https://docs.expo.dev/bare/installing-updates/#installation):
+If you're compiling for iOS, you'll need to install CocoaPods for your project. We recommend using [`pod-install`](https://www.npmjs.com/package/pod-install):
 
 <CodeGroup>
 ```bash 
@@ -90,7 +90,7 @@ module.exports = config;
 
 #### Monorepos
 
-For monorepos, use the following metro.config.js:
+For monorepos, use the following `metro.config.js`:
 
 <CodeGroup>
 ```ts
@@ -122,7 +122,7 @@ module.exports = config;
 ```
 </CodeGroup>
 
-### Additional monorepo configuration (for pnpm users)
+### Additional monorepo configuration (for pnpm)
 
 If you're using `pnpm`, you'll need to make sure that your expo app's `package.json` has this:
 
@@ -130,12 +130,13 @@ If you're using `pnpm`, you'll need to make sure that your expo app's `package.j
 ```json
 // package.json
 {
-  ...,
   "main": "index.js",
   ...
 }
 ```
 </CodeGroup>
+
+For more information, refer to [this Expo monorepo example](https://github.com/byCedric/expo-monorepo-example#pnpm-workarounds).
 
 ## Setting up the provider
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/project-setup/react-native-expo.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/project-setup/react-native-expo.mdx
@@ -1,8 +1,8 @@
-export const metadata = { title: "React Native - Expo" };
+export const metadata = { title: "React Native (Expo)" };
 
 import { CodeGroup } from "@/components/forMdx";
 
-# React Native - Expo
+# React Native (Expo) Installation and Setup
 
 Jazz supports Expo through the dedicated `jazz-expo` package, which is specifically designed for Expo applications.
 
@@ -11,42 +11,47 @@ Jazz requires an [Expo development build](https://docs.expo.dev/develop/developm
 Tested with:
 
 <CodeGroup>
-  ```json 
-  "expo": "~52.0.0", 
-  "react-native": "0.76.7", 
-  "react": "18.3.1"
-  ```
+```json 
+"expo": "~52.0.0", 
+"react-native": "0.76.7", 
+"react": "18.3.1"
+```
 </CodeGroup>
 
 ## Setup
 
 ### Create a new project
 
-(skip this step if you already have one)
+(Skip this step if you already have one)
 
 <CodeGroup>
   ```bash
-  npx create-expo-app -e with-router-tailwind my-jazz-app
-  cd my-jazz-app
-  npx expo prebuild
+npx create-expo-app -e with-router-tailwind my-jazz-app
+cd my-jazz-app
+npx expo prebuild
   ```
 </CodeGroup>
 
 ### Install dependencies
 
 <CodeGroup>
-  ```bash
-  npx expo install expo-linking expo-secure-store expo-file-system @react-native-community/netinfo @bam.tech/react-native-image-resizer
+```bash
+# Expo dependencies
+npx expo install expo-linking expo-secure-store expo-file-system @react-native-community/netinfo @bam.tech/react-native-image-resizer
 
-  npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer
+# React Native polyfills
+npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer
 
-  npm i -S jazz-tools jazz-expo jazz-react-native-media-images
-  ```
+# Jazz dependencies
+npm i -S jazz-tools jazz-expo jazz-react-native-media-images
+```
 </CodeGroup>
 
-> note: Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include `text-encoding` and `base-64`, and you can drop `@bacons/text-decoder`.
+**Note**: Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include: `text-encoding`, `base-64`, and you can drop `@bacons/text-decoder`.
 
-### Fix incompatible dependencies
+#### Fix incompatible dependencies
+
+If you encounter incompatible dependencies, you can try to fix them with the following command:
 
 <CodeGroup>
 ```bash
@@ -54,7 +59,9 @@ npx expo install --fix
 ```
 </CodeGroup>
 
-### Install Pods
+### Install CocoaPods
+
+If you're compiling for iOS, you'll need to install CocoaPods for your project. Expo recommend using the [`pod-install` command](https://docs.expo.dev/bare/installing-updates/#installation):
 
 <CodeGroup>
 ```bash 
@@ -66,16 +73,19 @@ npx pod-install
 
 #### Regular repositories
 
-If you are not working within a monorepo, create a new file metro.config.js in the root of your project with the following content:
+If you are not working within a monorepo, create a new file `metro.config.js` in the root of your project with the following content:
 
 <CodeGroup>
-  ```ts 
-  const {getDefaultConfig} = require("expo/metro-config"); 
-  const config = getDefaultConfig(projectRoot); 
-  config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"]; 
-  config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/]; 
-  module.exports = config; 
-  ```
+```ts 
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config"); 
+const config = getDefaultConfig(projectRoot); 
+  
+config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"]; 
+config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/]; 
+  
+module.exports = config; 
+```
 </CodeGroup>
 
 #### Monorepos
@@ -83,65 +93,76 @@ If you are not working within a monorepo, create a new file metro.config.js in t
 For monorepos, use the following metro.config.js:
 
 <CodeGroup>
-  ```ts
-  const { getDefaultConfig } = require("expo/metro-config");
-  const { FileStore } = require("metro-cache");
-  const path = require("path");
+```ts
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { FileStore } = require("metro-cache");
+const path = require("path");
 
-  // eslint-disable-next-line no-undef
-  const projectRoot = __dirname;
-  const workspaceRoot = path.resolve(projectRoot, "../..");
+// eslint-disable-next-line no-undef
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, "../..");
 
-  const config = getDefaultConfig(projectRoot);
+const config = getDefaultConfig(projectRoot);
 
-  config.watchFolders = [workspaceRoot];
-  config.resolver.nodeModulesPaths = [
-    path.resolve(projectRoot, "node_modules"),
-    path.resolve(workspaceRoot, "node_modules"),
-  ];
-  config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
-  config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/];
-  config.cacheStores = [
-    new FileStore({
-      root: path.join(projectRoot, "node_modules", ".cache", "metro"),
-    }),
-  ];
+config.watchFolders = [workspaceRoot];
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, "node_modules"),
+  path.resolve(workspaceRoot, "node_modules"),
+];
+config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
+config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/];
+config.cacheStores = [
+  new FileStore({
+    root: path.join(projectRoot, "node_modules", ".cache", "metro"),
+  }),
+];
 
-  module.exports = config;
-  ```
+module.exports = config;
+```
 </CodeGroup>
 
 ### Additional monorepo configuration (for pnpm users)
 
-If you're using pnpm, you'll need to make sure that your expo app's package.json has this:
+If you're using `pnpm`, you'll need to make sure that your expo app's `package.json` has this:
 
-<CodeGroup>```json "main": "index.js", ```</CodeGroup>
+<CodeGroup>
+```json
+// package.json
+{
+  ...,
+  "main": "index.js",
+  ...
+}
+```
+</CodeGroup>
 
 ## Setting up the provider
 
-Wrap your app components with the JazzProvider:
+Wrap your app components with the `<JazzProvider />` component:
 
 <CodeGroup>
 ```tsx
+// App.tsx
 import { JazzProvider } from "jazz-expo";
 import { MyAppAccount } from "./schema";
 
 export function MyJazzProvider({ children }: { children: React.ReactNode }) {
-    return (
-        <JazzProvider
-            sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
-            AccountSchema={MyAppAccount}
-        >
-            {children}
-        </JazzProvider>
-    );
+  return (
+    <JazzProvider
+      sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
+      AccountSchema={MyAppAccount}
+    >
+      {children}
+    </JazzProvider>
+  );
 }
 
 // Register the Account schema so `useAccount` returns our custom `MyAppAccount`
 declare module "jazz-expo" {
-    interface Register {
-        Account: MyAppAccount;
-    }
+  interface Register {
+    Account: MyAppAccount;
+  }
 }
 ```
 </CodeGroup>
@@ -169,7 +190,12 @@ You can customize the storage options in the `JazzProvider`:
 
 <CodeGroup>
 ```tsx
-import { JazzProvider, ExpoSQLiteAdapter, ExpoSecureStoreAdapter } from "jazz-expo";
+// App.tsx
+import {
+  JazzProvider,
+  ExpoSQLiteAdapter,
+  ExpoSecureStoreAdapter,
+} from "jazz-expo";
 
 // Default configuration - no parameters needed
 <JazzProvider
@@ -201,6 +227,7 @@ To define what database types your app uses, create `schema.ts` with a CoValue s
 
 <CodeGroup>
 ```tsx
+// schema.ts
 import { Account, AuthSession, createCoValueClass, z } from "jazz-expo";
 
 export class Chat extends createCoValueClass("chat", {
@@ -230,6 +257,7 @@ Now you can create a chat, add messages, invite collaborators, or sync data acro
 
 <CodeGroup>
 ```tsx
+// MyComponent.tsx
 import { useAccount, useCoValue } from "jazz-expo";
 import { Chat, MyAppAccount } from "./schema";
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/project-setup/react-native.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/project-setup/react-native.mdx
@@ -2,46 +2,54 @@ export const metadata = { title: "React Native" };
 
 import { CodeGroup } from "@/components/forMdx";
 
-# React Native
+# React Native Installation and Setup
 
-This guide covers setting up Jazz with framework-less React Native applications (without Expo). If you're using Expo, please refer to the [React Native - Expo](/docs/react-native-expo/project-setup) guide instead.
+This guide covers setting up Jazz for React Native applications. If you're using Expo, please refer to the [React Native - Expo](/docs/react-native-expo/project-setup) guide instead.
 
 Jazz supports the [New Architecture](https://reactnative.dev/architecture/landing-page) for React Native.
 
 Tested with:
 
 <CodeGroup>
-  ```json "react-native": "0.76.7", "react": "18.3.1" ```
+```json 
+"react-native": "0.76.7",
+"react": "18.3.1" 
+```
 </CodeGroup>
 
 ## Setup
 
 ### Create a new project
 
-(skip this step if you already have one)
+(Skip this step if you already have one)
 
 <CodeGroup>
-  ```bash
-  npx react-native init MyJazzApp
-  cd MyJazzApp
-  ```
+```bash
+npx react-native init my-jazz-app
+cd my-jazz-app
+```
 </CodeGroup>
 
 ### Install dependencies
 
 <CodeGroup>
-  ```bash
-  npm install @react-native-community/netinfo @bam.tech/react-native-image-resizer
+```bash
+# React Native dependencies
+npm install @react-native-community/netinfo @bam.tech/react-native-image-resizer
 
-  npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer @op-engineering/op-sqlite react-native-mmkv
+# React Native polyfills
+npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values @craftzdog/react-native-buffer @op-engineering/op-sqlite react-native-mmkv
 
-  npm i -S jazz-tools jazz-react-native jazz-react-native-media-images
-  ```
+# Jazz dependencies
+npm i -S jazz-tools jazz-react-native jazz-react-native-media-images
+```
 </CodeGroup>
 
-> note: Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include `text-encoding` and `base-64`, and you can drop `@bacons/text-decoder`.
+**Note**: Hermes has added support for `atob` and `btoa` in React Native 0.74. If you are using earlier versions, you may also need to polyfill `atob` and `btoa` in your `package.json`. Packages to try include `text-encoding` and `base-64`, and you can drop `@bacons/text-decoder`.
 
-### Install Pods
+### Install CocoaPods
+
+If you're compiling for iOS, you'll need to install CocoaPods for your project. We recommend using [`pod-install`](https://www.npmjs.com/package/pod-install):
 
 <CodeGroup>
 ```bash
@@ -53,56 +61,63 @@ npx pod-install
 
 #### Regular repositories
 
-If you are not working within a monorepo, create a new file metro.config.js in the root of your project with the following content:
+If you are not working within a monorepo, create a new file `metro.config.js` in the root of your project with the following content:
 
 <CodeGroup>
-  ```ts const {getDefaultConfig} = require("expo/metro-config"); const config =
-  getDefaultConfig(projectRoot); config.resolver.sourceExts = ["mjs", "js",
-  "json", "ts", "tsx"]; config.resolver.requireCycleIgnorePatterns =
-  [/(^|\/|\\)node_modules($|\/|\\)/]; module.exports = config; ```
+```ts
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const config = getDefaultConfig(projectRoot);
+
+config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
+config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/];
+
+module.exports = config;
+```
 </CodeGroup>
 
 #### Monorepos
 
-For monorepos, use the following metro.config.js:
+For monorepos, use the following `metro.config.js`:
 
 <CodeGroup>
-  ```ts
-  const { getDefaultConfig } = require("expo/metro-config");
-  const { FileStore } = require("metro-cache");
-  const path = require("path");
+```ts
+// metro.config.js
+const { getDefaultConfig } = require("expo/metro-config");
+const { FileStore } = require("metro-cache");
+const path = require("path");
 
 // eslint-disable-next-line no-undef
-const projectRoot = \_\_dirname;
+const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, "../..");
 
 const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
 config.resolver.nodeModulesPaths = [
-path.resolve(projectRoot, "node_modules"),
-path.resolve(workspaceRoot, "node_modules"),
+  path.resolve(projectRoot, "node_modules"),
+  path.resolve(workspaceRoot, "node_modules"),
 ];
 config.resolver.sourceExts = ["mjs", "js", "json", "ts", "tsx"];
 config.resolver.requireCycleIgnorePatterns = [/(^|\/|\\)node_modules($|\/|\\)/];
 config.cacheStores = [
-new FileStore({
-root: path.join(projectRoot, "node_modules", ".cache", "metro"),
-}),
+  new FileStore({
+    root: path.join(projectRoot, "node_modules", ".cache", "metro"),
+  }),
 ];
 
 module.exports = config;
-
-````
+```
 </CodeGroup>
 
-### Additional monorepo configuration (for pnpm users)
+### Additional monorepo configuration (for pnpm)
 
-- Add node-linker=hoisted to the root .npmrc (create this file if it doesn’t exist).
-- Add the following to the root package.json:
+- Add `node-linker=hoisted` to the root `.npmrc` (create this file if it doesn't exist).
+- Add the following to the root `package.json`:
 
 <CodeGroup>
 ```json
+// package.json
 "pnpm": {
   "peerDependencyRules": {
     "ignoreMissing": [
@@ -112,78 +127,91 @@ module.exports = config;
     ]
   }
 }
-````
-
+```
 </CodeGroup>
-
-For more information, refer to [this](https://github.com/byCedric/expo-monorepo-example#pnpm-workarounds) Expo monorepo example.
 
 ### Add polyfills
 
 Create a file `polyfills.js` at the project root with the following content:
 
 <CodeGroup>
-  ```js
+```js
+// polyfills.js
 import { polyfillGlobal } from 'react-native/Libraries/Utilities/PolyfillFunctions';
-
 import { Buffer } from "@craftzdog/react-native-buffer";
-polyfillGlobal("Buffer", () => Buffer);
+polyfillGlobal("Buffer", () => Buffer); // polyfill Buffer
 
 import { ReadableStream } from "readable-stream";
-polyfillGlobal("ReadableStream", () => ReadableStream);
+polyfillGlobal("ReadableStream", () => ReadableStream); // polyfill ReadableStream
 
-import "@azure/core-asynciterator-polyfill";
-
-import "@bacons/text-decoder/install";
-
-import 'react-native-get-random-values';
+import "@azure/core-asynciterator-polyfill"; // polyfill Async Iterator
+import "@bacons/text-decoder/install"; // polyfill Text Decoder
+import 'react-native-get-random-values'; // polyfill getRandomValues
 ```
 </CodeGroup>
 
 Update `index.js` based on whether you are using expo-router or not:
 
-#### If using `expo-router`
+#### With `expo-router`
 
 <CodeGroup>
-  ```ts import "./polyfills"; import "expo-router/entry"; ```
+```ts
+// index.js
+import "./polyfills";
+import "expo-router/entry";
+```
 </CodeGroup>
 
 #### Without `expo-router`
 
 <CodeGroup>
-  ```ts import "./polyfills"; import {registerRootComponent} from "expo"; import
-  App from "./src/App"; registerRootComponent(App); ```
+```ts
+// index.js
+import "./polyfills";
+import { registerRootComponent } from "expo";
+import App from "./src/App";
+registerRootComponent(App);
+```
 </CodeGroup>
 
 Lastly, ensure that the `"main"` field in your `package.json` points to `index.js`:
 
-<CodeGroup>```json "main": "index.js", ```</CodeGroup>
+<CodeGroup>
+```json
+// package.json
+{
+  "main": "index.js",
+  ...
+}
+```
+</CodeGroup>
 
 ## Setting up the provider
 
-Wrap your app components with the JazzProvider:
+Wrap your app components with the `<JazzProvider />` component:
 
 <CodeGroup>
 ```tsx
+// App.tsx
 import { JazzProvider } from "jazz-react-native";
 import { MyAppAccount } from "./schema";
 
 export function MyJazzProvider({ children }: { children: React.ReactNode }) {
-    return (
-        <JazzProvider
-            sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
-            AccountSchema={MyAppAccount}
-        >
-            {children}
-        </JazzProvider>
-    );
+  return (
+    <JazzProvider
+      sync={{ peer: "wss://cloud.jazz.tools/?key=you@example.com" }}
+      AccountSchema={MyAppAccount}
+    >
+      {children}
+    </JazzProvider>
+  );
 }
 
 // Register the Account schema so `useAccount` returns our custom `MyAppAccount`
 declare module "jazz-react-native" {
-    interface Register {
-        Account: MyAppAccount;
-    }
+  interface Register {
+    Account: MyAppAccount;
+  }
 }
 ```
 </CodeGroup>
@@ -195,12 +223,12 @@ declare module "jazz-react-native" {
 - `AccountSchema`
   - `Account` (default)
 - `CryptoProvider`
-  - `PureJSCrypto` (default)
+  - `PureJSCrypto` (default) - Pure JavaScript crypto provider
   - `RNQuickCrypto` - C++ accelerated crypto provider
 
 ### Local Persistence
 
-Jazz for React Native includes built-in local persistence using SQLite. The framework-less React Native implementation uses:
+Jazz for React Native includes built-in local persistence using SQLite. This implementation uses:
 
 - **Database Storage**: `@op-engineering/op-sqlite` - A high-performance SQLite implementation
 - **Key-Value Storage**: `react-native-mmkv` - A fast key-value storage system
@@ -213,7 +241,12 @@ You can customize the storage options in the `JazzProvider`:
 
 <CodeGroup>
 ```tsx
-import { JazzProvider, OpSQLiteAdapter, MMKVStoreAdapter } from "jazz-react-native";
+// App.tsx 
+import {
+  JazzProvider,
+  OpSQLiteAdapter,
+  MMKVStoreAdapter,
+} from "jazz-react-native";
 
 // Default configuration - no parameters needed
 <JazzProvider
@@ -261,37 +294,35 @@ Jazz provides a complete solution for handling images in React Native, including
 To upload images, use the `createImage` function from `jazz-react-native-media-images`. This function handles image processing and creates an `ImageDefinition` that can be stored in your Jazz covalues:
 
 <CodeGroup>
-  ```tsx
-  import { createImage } from "jazz-react-native-media-images";
-  import * as ImagePicker from 'expo-image-picker';
+```tsx
+import { createImage } from "jazz-react-native-media-images";
+import * as ImagePicker from 'expo-image-picker';
 
 // Example: Image upload from device library
 const handleImageUpload = async () => {
-try {
-const result = await ImagePicker.launchImageLibraryAsync({
-mediaTypes: ImagePicker.MediaTypeOptions.Images,
-base64: true, // Important: We need base64 data
-quality: 0.7,
-});
+  try {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      base64: true, // Important: We need base64 data
+      quality: 0.7,
+    });
 
-      if (!result.canceled && result.assets[0].base64) {
-        const base64Uri = `data:image/jpeg;base64,${result.assets[0].base64}`;
+    if (!result.canceled && result.assets[0].base64) {
+      const base64Uri = `data:image/jpeg;base64,${result.assets[0].base64}`;
 
-        const image = await createImage(base64Uri, {
-          owner: someCovalue._owner,  // Set appropriate owner
-          maxSize: 2048,  // Optional: limit maximum image size
-        });
+      const image = await createImage(base64Uri, {
+        owner: someCovalue._owner,  // Set appropriate owner
+        maxSize: 2048,  // Optional: limit maximum image size
+      });
 
-        // Store the image in your covalue
-        someCovalue.image = image;
-      }
-    } catch (error) {
-      console.error('Failed to upload image:', error);
+      // Store the image in your covalue
+      someCovalue.image = image;
     }
-
+  } catch (error) {
+    console.error('Failed to upload image:', error);
+  }
 };
-
-````
+```
 </CodeGroup>
 
 #### Displaying Images
@@ -303,21 +334,21 @@ To display images, use the `ProgressiveImg` component from `jazz-react-native`. 
 import { ProgressiveImg } from "jazz-react-native";
 import { Image } from "react-native";
 
-  // Inside your render function:
-  <ProgressiveImg image={someCovalue.image} targetWidth={1024}>
-    {({ src, res, originalSize }) => (
-      <Image
-        source={{ uri: src }}
-        style={{
-          width: 300,  // Adjust size as needed
-          height: 300,
-          borderRadius: 8,
-        }}
-        resizeMode="cover"
-      />
-    )}
-  </ProgressiveImg>
-  ```
+// Inside your render function:
+<ProgressiveImg image={someCovalue.image} targetWidth={1024}>
+  {({ src, res, originalSize }) => (
+    <Image
+      source={{ uri: src }}
+      style={{
+        width: 300,  // Adjust size as needed
+        height: 300,
+        borderRadius: 8,
+      }}
+      resizeMode="cover"
+    />
+  )}
+</ProgressiveImg>
+```
 </CodeGroup>
 
 The `ProgressiveImg` component:
@@ -331,4 +362,9 @@ For a complete implementation example, see the [Chat Example](https://github.com
 
 ### Running your app
 
-<CodeGroup>```bash npx expo run:ios npx expo run:android ```</CodeGroup>
+<CodeGroup>
+```sh
+npx expo run:ios
+npx expo run:android
+```
+</CodeGroup>

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0.mdx
@@ -1,8 +1,8 @@
 import { ContentByFramework } from '@/components/forMdx'
 
-export const metadata = { title: "Upgrade to Jazz 0.13.0" };
+export const metadata = { title: "Jazz 0.13.0 - React Native Split" };
 
-# Upgrade to Jazz 0.13.0
+# Jazz 0.13.0 - React Native Split
 
 <ContentByFramework>
   {{

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0.mdx
@@ -4,34 +4,21 @@ export const metadata = { title: "Jazz 0.13.0 - React Native Split" };
 
 # Jazz 0.13.0 - React Native Split
 
-<ContentByFramework>
-  {{
-    "react-native": "📱 React Native now has separate implementations for Expo and framework-less React Native applications. [Learn how to upgrade →](/docs/react-native/upgrade/0-13-0)",
-    "react-native-expo": "📱 React Native now has a dedicated Jazz package with optimized implementations for Expo applications. [Learn how to upgrade →](/docs/react-native-expo/upgrade/0-13-0)",
-    "react": "✅ No breaking changes for React applications in this version.",
-    "vue": "✅ No breaking changes for Vue applications in this version.",
-    "svelte": "✅ No breaking changes for Svelte applications in this version.",
-    "default": "Version 0.13.0 introduces a significant architectural change for React Native implementations. For other frameworks, there are no breaking changes in this version."
-  }}
-</ContentByFramework>
+Version 0.13.0 introduces a significant architectural change in how Jazz supports React Native applications. We've separated the React Native implementation into two distinct packages to better serve different React Native development approaches:
+
+1. **[jazz-react-native](https://www.npmjs.com/package/jazz-react-native)**: Focused package for framework-less React Native applications
+2. **[jazz-expo](https://www.npmjs.com/package/jazz-expo)**: Dedicated package for Expo applications
+3. **[jazz-react-native-core](https://www.npmjs.com/package/jazz-react-native-core)**: Shared core functionality used by both implementations
+
+If you're using React Native without Expo, see the [React Native Upgrade Guide](/docs/react-native/upgrade/0-13-0). If you're using Expo, please see the [Expo upgrade guide](/docs/react-native-expo/upgrade/0-13-0).
 
 ## Summary of Changes
 
-### React Native Changes
+- **Split Implementation**: React Native support is now divided into separate packages for Expo and framework-less React Native
+- **Clerk Authentication**: Clerk auth is now included directly in the jazz-expo package
+- **Storage Adapters**: Each implementation uses platform-optimized storage solutions
 
-- **Split Implementation**: React Native support is now divided into two packages:
-  - `jazz-expo`: For Expo applications
-  - `jazz-react-native`: For framework-less React Native applications
-  - `jazz-react-native-core`: Shared core functionality used by both
+For detailed migration instructions, please see the appropriate guide:
 
-- **Storage Adapters**:
-  - Expo uses `expo-sqlite` and `expo-secure-store`
-  - Framework-less React Native uses `@op-engineering/op-sqlite` and `react-native-mmkv`
-
-- **Import Paths**: You'll need to update imports based on your implementation:
-  - From `jazz-react-native` to `jazz-expo` for Expo applications
-  - No changes needed for framework-less React Native applications
-
-### Other Frameworks
-
-No breaking changes for React, Vue, or Svelte applications in this version.
+- [Framework-less React Native Upgrade Guide](/docs/react-native/upgrade/0-13-0)
+- [Expo Upgrade Guide](/docs/react-native-expo/upgrade/0-13-0)

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
@@ -96,7 +96,14 @@ declare module "jazz-expo" {
 
 ## New Architecture Support
 
-The `jazz-expo` implementation supports the Expo New Architecture.
+The `jazz-expo` implementation fully supports [the React Native New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page) when used with compatible Expo SDK versions. See [Expo's New Architecture guide](https://docs.expo.dev/guides/new-architecture/) for details on using the New Architecture with Expo. This includes compatibility with:
+
+- JavaScript Interface (JSI) for more efficient JavaScript-to-native communication
+- Fabric rendering system for improved UI performance
+- TurboModules for better native module management
+- Codegen for type-safe interfaces
+
+No additional configuration is needed to use Jazz with Expo projects that use the New Architecture.
 
 ## Styling with NativeWind
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
@@ -1,8 +1,8 @@
 import { CodeGroup } from '@/components/forMdx'
 
-export const metadata = { title: "Upgrade to Jazz 0.13.0 for React Native Expo" };
+export const metadata = { title: "Jazz 0.13.0 - React Native Split" };
 
-# Upgrade to Jazz 0.13.0 for React Native Expo
+# Jazz 0.13.0 - React Native Split
 
 Version 0.13.0 introduces a significant architectural change in how Jazz supports React Native applications. We've separated the React Native implementation into two distinct packages to better serve different React Native development approaches:
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
@@ -18,8 +18,8 @@ This guide focuses on upgrading **Expo applications**. If you're using framework
 
 <CodeGroup>
 ```bash
-# Remove the old package
-npm uninstall jazz-react-native
+# Remove the old packages
+npm uninstall jazz-react-native jazz-react-native-clerk
 
 # Install the new Expo-specific packages
 npx expo install expo-sqlite expo-secure-store expo-file-system @react-native-community/netinfo
@@ -58,6 +58,26 @@ declare module "jazz-expo" { // *add*
 }
 ```
 </CodeGroup>
+
+## Clerk Authentication
+
+Clerk authentication has been moved inside the `jazz-expo` package. This is a breaking change that requires updating both your imports and providers.
+
+If you're using Clerk auth in your Expo application, you'll need to:
+
+<CodeGroup>
+```tsx
+// Old imports
+import { useClerkAuth } from "jazz-react-native-clerk";
+import { ClerkAuthProvider } from "jazz-react-native-clerk";
+
+// New imports
+import { useClerkAuth } from "jazz-expo/auth/clerk";
+import { ClerkAuthProvider } from "jazz-expo/auth/clerk";
+```
+</CodeGroup>
+
+Since Clerk only supports Expo applications, this consolidation makes sense and simplifies your dependency structure. You'll need to completely remove the `jazz-react-native-clerk` package from your dependencies and use the Clerk functionality that's now built into `jazz-expo`.
 
 ## Storage Adapter Changes
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native-expo.mdx
@@ -6,11 +6,11 @@ export const metadata = { title: "Jazz 0.13.0 - React Native Split" };
 
 Version 0.13.0 introduces a significant architectural change in how Jazz supports React Native applications. We've separated the React Native implementation into two distinct packages to better serve different React Native development approaches:
 
-1. **jazz-expo**: Dedicated package for Expo applications
-2. **jazz-react-native**: Focused package for framework-less React Native applications
-3. **jazz-react-native-core**: Shared core functionality used by both implementations (probably not imported directly)
+1. **[jazz-expo](https://www.npmjs.com/package/jazz-expo)**: Dedicated package for Expo applications
+2. **[jazz-react-native](https://www.npmjs.com/package/jazz-react-native)**: Focused package for framework-less React Native applications
+3. **[jazz-react-native-core](https://www.npmjs.com/package/jazz-react-native-core)**: Shared core functionality used by both implementations
 
-This guide focuses on upgrading **Expo applications**. If you're using framework-less React Native, please see the [React Native upgrade guide](/docs/react-native/upgrade/0-13-0).
+This guide focuses on upgrading **Expo applications**. If you're using React Native without Expo, please see the [React Native upgrade guide](/docs/react-native/upgrade/0-13-0).
 
 ## Migration Steps for Expo
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native.mdx
@@ -68,7 +68,14 @@ declare module "jazz-react-native" {
 
 ## New Architecture Support
 
-The `jazz-react-native` implementation supports the React Native New Architecture.
+The `jazz-react-native` implementation fully supports [the React Native New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page). This includes compatibility with:
+
+- JavaScript Interface (JSI) for more efficient JavaScript-to-native communication
+- Fabric rendering system for improved UI performance
+- TurboModules for better native module management
+- Codegen for type-safe interfaces
+
+No additional configuration is needed to use Jazz with the New Architecture.
 
 ## Potential Podfile Issues
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native.mdx
@@ -1,8 +1,8 @@
 import { CodeGroup } from '@/components/forMdx'
 
-export const metadata = { title: "Upgrade to Jazz 0.13.0 for React Native" };
+export const metadata = { title: "Jazz 0.13.0 - React Native Split" };
 
-# Upgrade to Jazz 0.13.0 for React Native
+# Jazz 0.13.0 - React Native Split
 
 Version 0.13.0 introduces a significant architectural change in how Jazz supports React Native applications. We've separated the React Native implementation into two distinct packages to better serve different React Native development approaches:
 

--- a/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native.mdx
+++ b/homepage/homepage/app/(docs)/docs/[framework]/[...slug]/upgrade/0-13-0/react-native.mdx
@@ -6,11 +6,11 @@ export const metadata = { title: "Jazz 0.13.0 - React Native Split" };
 
 Version 0.13.0 introduces a significant architectural change in how Jazz supports React Native applications. We've separated the React Native implementation into two distinct packages to better serve different React Native development approaches:
 
-1. **jazz-react-native**: Focused package for framework-less React Native applications
-2. **jazz-expo**: Dedicated package for Expo applications
-3. **jazz-react-native-core**: Shared core functionality used by both implementations (probably not imported directly)
+1. **[jazz-react-native](https://www.npmjs.com/package/jazz-react-native)**: Focused package for framework-less React Native applications
+2. **[jazz-expo](https://www.npmjs.com/package/jazz-expo)**: Dedicated package for Expo applications
+3. **[jazz-react-native-core](https://www.npmjs.com/package/jazz-react-native-core)**: Shared core functionality used by both implementations
 
-This guide focuses on upgrading **framework-less React Native** applications. If you're using Expo, please see the [Expo upgrade guide](/docs/react-native-expo/upgrade/0-13-0).
+This guide focuses on upgrading **React Native without Expo** applications. If you're using Expo, please see the [Expo upgrade guide](/docs/react-native-expo/upgrade/0-13-0).
 
 ## Migration Steps for Framework-less React Native
 

--- a/homepage/homepage/components/docs/FrameworkSelect.tsx
+++ b/homepage/homepage/components/docs/FrameworkSelect.tsx
@@ -29,7 +29,7 @@ const frameworks: Record<
     experimental: false,
   },
   [Framework.ReactNativeExpo]: {
-    label: "React Native Expo",
+    label: "React Native (Expo)",
     experimental: false,
   },
   [Framework.Vanilla]: {

--- a/homepage/homepage/lib/docNavigationItems.js
+++ b/homepage/homepage/lib/docNavigationItems.js
@@ -72,24 +72,9 @@ export const docNavigationItems = [
     prefix: "/docs/upgrade",
     items: [
       {
-        // upgrade guides
         name: "0.13.0 - React Native Split",
         href: "/docs/upgrade/0-13-0",
-        done: {
-          "react-native": 100,
-          "react-native-expo": 100,
-        },
-        framework: "react-native",
-      },
-      {
-        // upgrade guides
-        name: "0.13.0 - React Native Split",
-        href: "/docs/upgrade/0-13-0",
-        done: {
-          "react-native": 100,
-          "react-native-expo": 100,
-        },
-        framework: "react-native-expo",
+        done: 100
       },
       {
         // upgrade guides


### PR DESCRIPTION
Mostly tidy up, as @boorad added most of the content.

- Added detailed information about React Native New Architecture support
- Fixed formatting issues in code examples for better copy/paste experience
- Improved Clerk authentication migration instructions for Expo users
- Added cross-links between related guides
- Adjusted language to match Jazz tone and voice guidelines